### PR TITLE
Fix drag behavior for Show/Hide Columns menu items

### DIFF
--- a/packages/mantine-react-table-open/src/components/menus/MRT_ShowHideColumnsMenuItems.module.css
+++ b/packages/mantine-react-table-open/src/components/menus/MRT_ShowHideColumnsMenuItems.module.css
@@ -7,12 +7,16 @@
   padding-left: var(--_column-depth);
   padding-top: rem(6px);
   padding-bottom: rem(6);
+  border-radius: 6px;
   &[data-dragging] {
     opacity: 0.5;
     outline: 1px dashed var(--mantine-color-gray-7);
   }
   &[data-order-hovered]:not(&[data-dragging]) {
     outline: 2px dashed var(--_hover-color);
+  }
+  &:hover {
+    background-color: var(--menu-item-hover, var(--mantine-color-gray-1));
   }
 }
 .menu {

--- a/packages/mantine-react-table-open/src/components/menus/MRT_ShowHideColumnsMenuItems.tsx
+++ b/packages/mantine-react-table-open/src/components/menus/MRT_ShowHideColumnsMenuItems.tsx
@@ -10,7 +10,6 @@ import {
 
 import {
   Box,
-  Menu,
   Switch,
   Text,
   Tooltip,
@@ -102,7 +101,7 @@ export const MRT_ShowHideColumnsMenuItems = <TData extends MRT_RowData>({
 
   return (
     <>
-      <Menu.Item
+      <Box
         className={classes.root}
         component="span"
         onDragEnter={handleDragEnter}
@@ -153,7 +152,7 @@ export const MRT_ShowHideColumnsMenuItems = <TData extends MRT_RowData>({
             <Text className={classes.header}>{columnDef.header}</Text>
           )}
         </Box>
-      </Menu.Item>
+      </Box>
       {column.columns?.map((c: MRT_Column<TData>, i) => (
         <MRT_ShowHideColumnsMenuItems
           allColumns={allColumns}


### PR DESCRIPTION
Fix for details panel column dragging

I've prepared a fix for the issue where dragging columns in the details panel stopped working ([#issuecomment-3088834234](https://github.com/KevinVandy/mantine-react-table/issues/516#issuecomment-3088834234)). This won't be addressed in the Mantine package, so this PR includes a custom solution to restore the functionality.