### PR TITLE
Fix duplicate clear buttons in MultiSelect filter

### DIFF
--- a/packages/mantine-react-table-open/src/components/inputs/MRT_FilterTextInput.tsx
+++ b/packages/mantine-react-table-open/src/components/inputs/MRT_FilterTextInput.tsx
@@ -299,6 +299,7 @@ export const MRT_FilterTextInput = <TData extends MRT_RowData>({
         searchable
         {...multiSelectProps}
         className={clsx(className, multiSelectProps.className)}
+        clearable={false}
         data={filterSelectOptions}
         onChange={(value) => setFilterValue(value)}
         ref={(node) => {
@@ -315,6 +316,7 @@ export const MRT_FilterTextInput = <TData extends MRT_RowData>({
             ? ClearButton
             : undefined
         }
+        rightSectionPointerEvents="all"
         style={commonProps.style}
       />
     );


### PR DESCRIPTION
As you can see locally in the story http://localhost:6007/?path=/story/features-filtering-examples--filter-fn-and-filter-variants-faceted, there are two "clear all" buttons in the MultiSelect filter. This PR removes the clear all button of MultiSelect in favor of MRT's own clear all button, and enables functionality.

<img width="1313" height="307" alt="image" src="https://github.com/user-attachments/assets/76270648-9f33-41f6-ac04-e35bda3f80b8" />
